### PR TITLE
Uniform homepage layout - disable special first post

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -39,7 +39,7 @@ theme = "PaperMod"
   ShowShareButtons = false
   ShowPostNavLinks = true
   ShowTags = true
-  
+  disableSpecial1stPost = true
 
   # コードブロックにアイコン表示
   ShowCodeCopyButtons = true


### PR DESCRIPTION
## Summary
- Disable the special first post layout on homepage for uniform appearance
- All posts now display with consistent card styling and sizing

## Changes
- Add `disableSpecial1stPost = true` to config.toml
- Removes the prominent styling from the latest article

## Test plan
- [x] Verify homepage displays all posts with uniform styling
- [x] Confirm no visual regressions in post cards
- [x] Test responsive behavior remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)