### PR TITLE
Implement homepage tags functionality and tag pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,6 +8,11 @@ theme = "PaperMod"
 [permalinks]
   posts = "/posts/:filename/"
 
+# タクソノミー（タグとカテゴリ）
+[taxonomies]
+  tag = "tags"
+  category = "categories"
+
 # メニュー（任意で追加）
 [menu]
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,125 @@
+{{- define "main" }}
+
+{{- if (and site.Params.profileMode.enabled .IsHome) }}
+{{- partial "index_profile.html" . }}
+{{- else }} {{/* if not profileMode */}}
+
+{{- if not .IsHome | and .Title }}
+<header class="page-header">
+  {{- partial "breadcrumbs.html" . }}
+  <h1>
+    {{ .Title }}
+    {{- if and (or (eq .Kind `term`) (eq .Kind `section`)) (.Param "ShowRssButtonInSectionTermList") }}
+    {{- with .OutputFormats.Get "rss" }}
+    <a href="{{ .RelPermalink }}" title="RSS" aria-label="RSS">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+        stroke-linecap="round" stroke-linejoin="round" height="23">
+        <path d="M4 11a9 9 0 0 1 9 9" />
+        <path d="M4 4a16 16 0 0 1 16 16" />
+        <circle cx="5" cy="19" r="1" />
+      </svg>
+    </a>
+    {{- end }}
+    {{- end }}
+  </h1>
+  {{- if .Description }}
+  <div class="post-description">
+    {{ .Description | markdownify }}
+  </div>
+  {{- end }}
+</header>
+{{- end }}
+
+{{- if .Content }}
+<div class="post-content">
+  {{- if not (.Param "disableAnchoredHeadings") }}
+  {{- partial "anchored_headings.html" .Content -}}
+  {{- else }}{{ .Content }}{{ end }}
+</div>
+{{- end }}
+
+{{- $pages := union .RegularPages .Sections }}
+
+{{- if .IsHome }}
+{{- $pages = where site.RegularPages "Type" "in" site.Params.mainSections }}
+{{- $pages = where $pages "Params.hiddenInHomeList" "!=" "true"  }}
+{{- end }}
+
+{{- $paginator := .Paginate $pages }}
+
+{{- if and .IsHome site.Params.homeInfoParams (eq $paginator.PageNumber 1) }}
+{{- partial "home_info.html" . }}
+{{- end }}
+
+{{- $term := .Data.Term }}
+{{- range $index, $page := $paginator.Pages }}
+
+{{- $class := "post-entry" }}
+
+{{- $user_preferred := or site.Params.disableSpecial1stPost site.Params.homeInfoParams }}
+{{- if (and $.IsHome (eq $paginator.PageNumber 1) (eq $index 0) (not $user_preferred)) }}
+{{- $class = "first-entry" }}
+{{- else if $term }}
+{{- $class = "post-entry tag-entry" }}
+{{- end }}
+
+<article class="{{ $class }}">
+  {{- $isHidden := (.Param "cover.hiddenInList") | default (.Param "cover.hidden") | default false }}
+  {{- partial "cover.html" (dict "cxt" . "IsSingle" false "isHidden" $isHidden) }}
+  <header class="entry-header">
+    <h2 class="entry-hint-parent">
+      {{- .Title }}
+      {{- if .Draft }}
+      <span class="entry-hint" title="Draft">
+        <svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 -960 960 960" fill="currentColor">
+          <path
+            d="M160-410v-60h300v60H160Zm0-165v-60h470v60H160Zm0-165v-60h470v60H160Zm360 580v-123l221-220q9-9 20-13t22-4q12 0 23 4.5t20 13.5l37 37q9 9 13 20t4 22q0 11-4.5 22.5T862.09-380L643-160H520Zm300-263-37-37 37 37ZM580-220h38l121-122-18-19-19-18-122 121v38Zm141-141-19-18 37 37-18-19Z" />
+        </svg>
+      </span>
+      {{- end }}
+    </h2>
+  </header>
+  {{- if .Params.tags }}
+  <div class="entry-content">
+    <div class="entry-tags">
+      {{- range .Params.tags }}
+      <a href="/tags/{{ urlize . }}" class="tag-chip">{{ . }}</a>
+      {{- end }}
+    </div>
+  </div>
+  {{- end }}
+  {{- if not (.Param "hideMeta") }}
+  <footer class="entry-footer">
+    {{- partial "post_meta.html" . -}}
+  </footer>
+  {{- end }}
+  <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>
+</article>
+{{- end }}
+
+{{- if gt $paginator.TotalPages 1 }}
+<footer class="page-footer">
+  <nav class="pagination">
+    {{- if $paginator.HasPrev }}
+    <a class="prev" href="{{ $paginator.Prev.URL | absURL }}">
+      «&nbsp;{{ i18n "prev_page" }}&nbsp;
+      {{- if (.Param "ShowPageNums") }}
+      {{- sub $paginator.PageNumber 1 }}/{{ $paginator.TotalPages }}
+      {{- end }}
+    </a>
+    {{- end }}
+    {{- if $paginator.HasNext }}
+    <a class="next" href="{{ $paginator.Next.URL | absURL }}">
+      {{- i18n "next_page" }}&nbsp;
+      {{- if (.Param "ShowPageNums") }}
+      {{- add 1 $paginator.PageNumber }}/{{ $paginator.TotalPages }}
+      {{- end }}&nbsp;»
+    </a>
+    {{- end }}
+  </nav>
+</footer>
+{{- end }}
+
+{{- end }}{{/* end profileMode */}}
+
+{{- end }}{{- /* end main */ -}}

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -1,0 +1,96 @@
+{{- /* Custom CSS for tag chips and tag pages */ -}}
+<style>
+.entry-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.tag-chip {
+  display: inline-block;
+  padding: 4px 8px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--secondary);
+  background: var(--tertiary);
+  border-radius: 12px;
+  text-decoration: none;
+  transition: all 0.2s ease;
+  border: 1px solid var(--border);
+  position: relative;
+  z-index: 10;
+}
+
+.tag-chip:hover {
+  background: var(--primary);
+  color: var(--theme);
+  transform: translateY(-1px);
+}
+
+.dark .tag-chip {
+  background: var(--tertiary);
+  color: var(--primary);
+}
+
+.dark .tag-chip:hover {
+  background: var(--primary);
+  color: var(--theme);
+}
+
+/* Tag cloud styling for /tags/ page */
+.tags-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.tag-cloud-item {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 12px;
+  background: var(--entry);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  text-decoration: none;
+  transition: all 0.2s ease;
+  color: var(--primary);
+}
+
+.tag-cloud-item:hover {
+  background: var(--primary);
+  color: var(--theme);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+.tag-name {
+  font-weight: 500;
+  margin-right: 6px;
+}
+
+.tag-count {
+  font-size: 12px;
+  background: var(--tertiary);
+  color: var(--secondary);
+  padding: 2px 6px;
+  border-radius: 8px;
+  font-weight: 600;
+}
+
+.tag-cloud-item:hover .tag-count {
+  background: var(--theme);
+  color: var(--primary);
+}
+
+.dark .tag-cloud-item {
+  background: var(--entry);
+  color: var(--primary);
+}
+
+.dark .tag-cloud-item:hover {
+  background: var(--primary);
+  color: var(--theme);
+}
+</style>

--- a/layouts/tags/list.html
+++ b/layouts/tags/list.html
@@ -1,0 +1,78 @@
+{{- define "main" }}
+
+<header class="page-header">
+  <h1>
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 8px;">
+      <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/>
+      <line x1="7" y1="7" x2="7.01" y2="7"/>
+    </svg>
+    Tag: {{ .Title }}
+  </h1>
+  <div class="post-description">
+    {{ .Data.Pages | len }} {{ if eq (.Data.Pages | len) 1 }}post{{ else }}posts{{ end }} tagged with "{{ .Title }}"
+  </div>
+</header>
+
+{{- $pages := .Data.Pages }}
+{{- $paginator := .Paginate $pages }}
+
+{{- range $index, $page := $paginator.Pages }}
+
+<article class="post-entry">
+  {{- $isHidden := (.Param "cover.hiddenInList") | default (.Param "cover.hidden") | default false }}
+  {{- partial "cover.html" (dict "cxt" . "IsSingle" false "isHidden" $isHidden) }}
+  <header class="entry-header">
+    <h2 class="entry-hint-parent">
+      {{- .Title }}
+      {{- if .Draft }}
+      <span class="entry-hint" title="Draft">
+        <svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 -960 960 960" fill="currentColor">
+          <path
+            d="M160-410v-60h300v60H160Zm0-165v-60h470v60H160Zm0-165v-60h470v60H160Zm360 580v-123l221-220q9-9 20-13t22-4q12 0 23 4.5t20 13.5l37 37q9 9 13 20t4 22q0 11-4.5 22.5T862.09-380L643-160H520Zm300-263-37-37 37 37ZM580-220h38l121-122-18-19-19-18-122 121v38Zm141-141-19-18 37 37-18-19Z" />
+        </svg>
+      </span>
+      {{- end }}
+    </h2>
+  </header>
+  {{- if .Params.tags }}
+  <div class="entry-content">
+    <div class="entry-tags">
+      {{- range .Params.tags }}
+      <a href="/tags/{{ urlize . }}" class="tag-chip">{{ . }}</a>
+      {{- end }}
+    </div>
+  </div>
+  {{- end }}
+  {{- if not (.Param "hideMeta") }}
+  <footer class="entry-footer">
+    {{- partial "post_meta.html" . -}}
+  </footer>
+  {{- end }}
+  <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>
+</article>
+{{- end }}
+
+{{- if gt $paginator.TotalPages 1 }}
+<footer class="page-footer">
+  <nav class="pagination">
+    {{- if $paginator.HasPrev }}
+    <a class="prev" href="{{ $paginator.Prev.URL | absURL }}">
+      «&nbsp;{{ i18n "prev_page" }}&nbsp;
+      {{- if (.Param "ShowPageNums") }}
+      {{- sub $paginator.PageNumber 1 }}/{{ $paginator.TotalPages }}
+      {{- end }}
+    </a>
+    {{- end }}
+    {{- if $paginator.HasNext }}
+    <a class="next" href="{{ $paginator.Next.URL | absURL }}">
+      {{- i18n "next_page" }}&nbsp;
+      {{- if (.Param "ShowPageNums") }}
+      {{- add 1 $paginator.PageNumber }}/{{ $paginator.TotalPages }}
+      {{- end }}&nbsp;»
+    </a>
+    {{- end }}
+  </nav>
+</footer>
+{{- end }}
+
+{{- end }}{{- /* end main */ -}}

--- a/layouts/tags/terms.html
+++ b/layouts/tags/terms.html
@@ -1,0 +1,30 @@
+{{- define "main" }}
+
+<header class="page-header">
+    <h1>
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 8px;">
+        <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/>
+        <line x1="7" y1="7" x2="7.01" y2="7"/>
+      </svg>
+      All Tags
+    </h1>
+    <div class="post-description">
+        Browse posts by topic
+    </div>
+</header>
+
+<div class="tags-cloud">
+    {{- $type := .Type }}
+    {{- range $key, $value := .Data.Terms.Alphabetical }}
+    {{- $name := .Name }}
+    {{- $count := .Count }}
+    {{- with site.GetPage (printf "/%s/%s" $type $name) }}
+    <a href="{{ .Permalink }}" class="tag-cloud-item">
+        <span class="tag-name">{{ .Name }}</span>
+        <span class="tag-count">{{ $count }}</span>
+    </a>
+    {{- end }}
+    {{- end }}
+</div>
+
+{{- end }}{{/* end main */ -}}


### PR DESCRIPTION
## Summary
- Replace post descriptions with interactive tags on homepage
- Add comprehensive tag page system for browsing posts by topic
- Implement beautiful tag cloud for discovering all available tags

## Homepage Changes
- **Replace descriptions with tags**: Post summaries replaced with clickable tag chips
- **Interactive navigation**: Click tags to browse posts by topic
- **Visual improvements**: Modern tag chip design with hover effects
- **Fixed click handling**: Tags properly clickable over post overlay links

## Tag Pages Implementation
- **Individual tag pages**: `/tags/{tag-name}/` showing all posts with that tag
- **Tag overview page**: `/tags/` displaying all available tags with post counts
- **Consistent styling**: Same card layout as homepage for tag page posts
- **Beautiful headers**: Tag icons and post counts for context

## Technical Implementation
- **Hugo taxonomy system**: Proper configuration for tag URL generation
- **Template overrides**: Custom layouts without modifying theme files
- **CSS styling**: Comprehensive styling for tags with dark mode support
- **Responsive design**: Works seamlessly on all screen sizes

## Files Added
- `layouts/_default/list.html` - Homepage with tags instead of descriptions
- `layouts/tags/list.html` - Individual tag pages
- `layouts/tags/terms.html` - All tags overview page
- `layouts/partials/extend_head.html` - Custom CSS styling
- Updated `config.toml` with taxonomy configuration

## Test Plan
- [x] Verify homepage displays tags instead of descriptions
- [x] Confirm tag clicks navigate to correct tag pages
- [x] Test tag pages show correct posts and counts
- [x] Validate styling works in both light and dark modes
- [x] Ensure responsive behavior on mobile devices

🤖 Generated with [Claude Code](https://claude.ai/code)