### PR TITLE
Add social media navigation links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,6 +28,24 @@ theme = "PaperMod"
   url = "/posts/"
   weight = 2
 
+[[menu.main]]
+  identifier = "github"
+  name = "GitHub"
+  url = "https://github.com/jarinosuke"
+  weight = 3
+
+[[menu.main]]
+  identifier = "twitter"
+  name = "Twitter"
+  url = "https://twitter.com/jarinosuke"
+  weight = 4
+
+[[menu.main]]
+  identifier = "bluesky"
+  name = "Bluesky"
+  url = "https://bsky.app/profile/jarinosuke.bsky.social"
+  weight = 5
+
 # 各種パラメータ
 [params]
   mainSections = ["posts"]
@@ -45,6 +63,7 @@ theme = "PaperMod"
   ShowPostNavLinks = true
   ShowTags = true
   disableSpecial1stPost = true
+  displayFullLangName = true
 
   # コードブロックにアイコン表示
   ShowCodeCopyButtons = true


### PR DESCRIPTION
## Summary
• Add GitHub, Twitter, and Bluesky links to the main navigation menu
• Configure external links with proper weights for header menu ordering
• Enable displayFullLangName parameter for better internationalization support

## Test plan
- [ ] Verify social media links appear in header navigation
- [ ] Test that links open to correct external URLs
- [ ] Check menu ordering displays correctly (Home, Posts, GitHub, Twitter, Bluesky)
- [ ] Confirm links work across different pages

🤖 Generated with [Claude Code](https://claude.ai/code)