### PR TITLE
Add circular hero image with kuwagata.tron.png

### DIFF
--- a/astro-blog/src/components/HeroImage.astro
+++ b/astro-blog/src/components/HeroImage.astro
@@ -1,0 +1,50 @@
+---
+// ABOUTME: Hero image component that displays a circular profile image
+// ABOUTME: Used in the main hero section with hover effects and link to about page
+
+interface Props {
+  src: string;
+  alt: string;
+  href?: string;
+  className?: string;
+}
+
+const { src, alt, href = "/about", className = "" } = Astro.props;
+---
+
+{href ? (
+  <a href={href} class={`hero-image-link ${className}`} aria-label="Go to about page">
+    <img src={src} alt={alt} class="hero-image" />
+  </a>
+) : (
+  <img src={src} alt={alt} class={`hero-image ${className}`} />
+)}
+
+<style>
+  .hero-image-link {
+    display: inline-block;
+    flex-shrink: 0;
+  }
+  
+  .hero-image {
+    width: 7rem;
+    height: 7rem;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 2px solid var(--color-border);
+    transition: all 0.3s ease-in-out;
+  }
+  
+  .hero-image:hover {
+    transform: scale(1.05);
+    border-color: var(--color-accent);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+  }
+  
+  @media (min-width: 640px) {
+    .hero-image {
+      width: 9rem;
+      height: 9rem;
+    }
+  }
+</style>

--- a/astro-blog/src/components/Hr.astro
+++ b/astro-blog/src/components/Hr.astro
@@ -7,5 +7,5 @@ const { noPadding = false } = Astro.props;
 ---
 
 <div class={`flex justify-center ${noPadding ? "" : "my-8"}`}>
-  <div class="w-24 h-px bg-skin-line/30"></div>
+  <div class="w-full h-px bg-blue-500/50"></div>
 </div>

--- a/astro-blog/src/layouts/Main.astro
+++ b/astro-blog/src/layouts/Main.astro
@@ -23,7 +23,7 @@ export interface Props {
 
 <style>
   #main-content {
-    margin: 2rem auto;
+    margin: 0 auto 2rem auto;
     padding: 0 1.5rem;
     max-width: theme("screens.xl");
   }

--- a/astro-blog/src/pages/index.astro
+++ b/astro-blog/src/pages/index.astro
@@ -4,6 +4,7 @@ import Main from '@layouts/Main.astro';
 import Card from '@components/Card.astro';
 import Hr from '@components/Hr.astro';
 import LinkButton from '@components/LinkButton.astro';
+import HeroImage from '@components/HeroImage.astro';
 import getSortedPosts from '@utils/getSortedPosts';
 import { getReadingTime } from '@utils/getReadingTime';
 import { SITE, SOCIALS } from '@config';
@@ -18,74 +19,92 @@ const recentPosts = sortedPosts.slice(0, 4);
 	title={SITE.title}
 	description={SITE.desc}
 >
-	<section id="hero" class="pb-6 pt-8">
-		<h1 class="my-4 inline-block text-3xl font-bold sm:my-8 sm:text-5xl">
-			{SITE.title}
-		</h1>
-		<a
-			target="_blank"
-			href="/rss.xml"
-			class="mb-6 ml-4 inline-block"
-			aria-label="rss feed"
-			title="RSS Feed"
-		>
-			<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 scale-110 fill-skin-accent sm:scale-125">
-				<path d="M6.503 20.752c0 1.794-1.456 3.248-3.251 3.248S0 22.546 0 20.752s1.456-3.248 3.252-3.248 3.251 1.454 3.251 3.248zm-6.503-12.572v4.811c6.05.062 10.96 4.966 11.022 11.009h4.817c-.062-8.71-7.118-15.758-15.839-15.82zm0-3.368c10.58.046 19.152 8.594 19.183 19.188h4.817c-.03-13.231-10.755-23.954-24-24v4.812z"/>
-			</svg>
-		</a>
-
-		<p class="my-2">
-			{SITE.desc}
-		</p>
-		{
-			// only display if at least one social link is enabled
-			SOCIALS && SOCIALS.length > 0 && (
-				<div class="social-wrapper">
-					<div class="social-links">Links:</div>
-					<LinkButton
-						href="/search/"
-						className="hover:text-skin-accent underline underline-offset-4 decoration-dashed"
+	<section id="hero" class="py-8">
+		<div class="hero-container">
+			<HeroImage 
+				src="/kuwagata.tron.png" 
+				alt="jarinosuke profile image" 
+				className="hero-image-wrapper"
+			/>
+			<div class="hero-content">
+				<div class="hero-title-wrapper">
+					<h1 class="hero-title">
+						{SITE.title}
+					</h1>
+					<a
+						target="_blank"
+						href="/rss.xml"
+						class="rss-link"
+						aria-label="rss feed"
+						title="RSS Feed"
 					>
-						Search
-					</LinkButton>
-					{SOCIALS.map(social => (
-						social.active && (
-							<LinkButton
-								href={social.href}
-								className="hover:text-skin-accent underline underline-offset-4 decoration-dashed"
-								ariaLabel={social.name}
-							>
-								{social.name}
-							</LinkButton>
-						)
-					))}
+						<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 scale-110 fill-skin-accent sm:scale-125">
+							<path d="M6.503 20.752c0 1.794-1.456 3.248-3.251 3.248S0 22.546 0 20.752s1.456-3.248 3.252-3.248 3.251 1.454 3.251 3.248zm-6.503-12.572v4.811c6.05.062 10.96 4.966 11.022 11.009h4.817c-.062-8.71-7.118-15.758-15.839-15.82zm0-3.368c10.58.046 19.152 8.594 19.183 19.188h4.817c-.03-13.231-10.755-23.954-24-24v4.812z"/>
+						</svg>
+					</a>
 				</div>
-			)
-		}
+
+				<p class="hero-description">
+					{SITE.desc}
+				</p>
+				
+				{
+					// only display if at least one social link is enabled
+					SOCIALS && SOCIALS.length > 0 && (
+						<div class="social-wrapper">
+							<!-- Twitter -->
+							<a
+								href="https://twitter.com/jarinosuke"
+								target="_blank"
+								class="social-icon-link"
+								aria-label="Twitter"
+							>
+								<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+									<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+								</svg>
+							</a>
+							
+							<!-- GitHub -->
+							<a
+								href="https://github.com/jarinosuke"
+								target="_blank"
+								class="social-icon-link"
+								aria-label="GitHub"
+							>
+								<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+									<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+								</svg>
+							</a>
+							
+							<!-- LinkedIn -->
+							<a
+								href="https://linkedin.com/in/jarinosuke"
+								target="_blank"
+								class="social-icon-link"
+								aria-label="LinkedIn"
+							>
+								<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+									<path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+								</svg>
+							</a>
+							
+							<!-- Bluesky -->
+							<a
+								href="https://jarinosuke.bsky.social"
+								target="_blank"
+								class="social-icon-link"
+								aria-label="Bluesky"
+							>
+								<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+									<path d="M12 10.8c-1.087-2.114-4.046-6.053-6.798-7.995C2.566.944 1.561 1.266.902 1.565.139 1.908 0 3.08 0 3.768c0 .69.378 5.65.624 6.479.815 2.736 3.713 3.66 6.383 3.364.136-.02.275-.039.415-.056-.138.022-.276.04-.415.056-2.67-.296-5.568.628-6.383 3.364C.378 17.702 0 22.661 0 23.35c0 .688.139 1.86.902 2.203.659.299 1.664.621 4.3-1.24C7.954 22.47 10.913 18.532 12 16.418c1.087 2.114 4.046 6.053 6.798 7.995 2.636 1.861 3.641 1.539 4.3 1.24.763-.343.902-1.515.902-2.203 0-.689-.378-5.648-.624-6.477-.815-2.736-3.713-3.66-6.383-3.364-.139.017-.277.034-.415.056.138-.017.276-.036.415-.056 2.67.296 5.568-.628 6.383-3.364.246-.829.624-5.79.624-6.479 0-.688-.139-1.86-.902-2.203-.659-.299-1.664-.621-4.3 1.24C16.046 4.747 13.087 8.686 12 10.8z"/>
+								</svg>
+							</a>
+						</div>
+					)
+				}
+			</div>
+		</div>
 	</section>
-
-	<Hr />
-
-	{
-		featuredPosts.length > 0 && (
-			<>
-				<section id="featured">
-					<h2 class="text-2xl font-bold tracking-wide">Featured</h2>
-					<ul>
-						{featuredPosts.map((post) => (
-							<Card
-								href={`/blog/${post.id}/`}
-								frontmatter={post.data}
-								secHeading={false}
-								readingTime={getReadingTime(post.body).text}
-							/>
-						))}
-					</ul>
-				</section>
-				<Hr />
-			</>
-		)
-	}
 
 	<section id="recent-posts">
 		<h2 class="text-2xl font-bold tracking-wide">Recent Posts</h2>
@@ -114,33 +133,55 @@ const recentPosts = sortedPosts.slice(0, 4);
 <style>
   /* Hero */
   #hero {
-    @apply pb-6 pt-8;
+    @apply py-8;
   }
-  #hero h1 {
-    @apply my-4 inline-block text-3xl font-bold sm:my-8 sm:text-5xl;
+  
+  .hero-container {
+    @apply flex flex-col sm:flex-row items-start gap-6;
   }
-  #hero .rss-link {
-    @apply mb-6;
+  
+  .hero-content {
+    @apply flex-1;
   }
-  #hero .rss-icon {
-    @apply mb-2 h-6 w-6 scale-110 fill-skin-accent sm:mb-3 sm:scale-125;
+  
+  .hero-title-wrapper {
+    @apply flex items-center gap-4 mb-3;
   }
-  #hero p {
-    @apply my-2;
+  
+  .hero-title {
+    @apply text-3xl font-bold sm:text-5xl;
   }
+  
+  .rss-link {
+    @apply flex-shrink-0;
+  }
+  
+  .hero-description {
+    @apply mb-4 text-base sm:text-lg;
+  }
+  
   .social-wrapper {
-    @apply mt-4 flex flex-wrap gap-x-2 gap-y-1;
+    @apply flex flex-wrap items-center gap-x-4 gap-y-2;
   }
-  .social-links {
-    @apply mr-2 whitespace-nowrap sm:mr-4;
+  
+  .social-icon-link {
+    @apply text-skin-base hover:text-skin-accent transition-colors duration-300;
+  }
+  
+  @media (max-width: 639px) {
+    .hero-container {
+      @apply text-center;
+    }
+    
+    .hero-title-wrapper {
+      @apply justify-center;
+    }
   }
 
-  /* Featured */
-  #featured,
+  /* Recent Posts */
   #recent-posts {
     @apply pb-6;
   }
-  #featured h2,
   #recent-posts h2 {
     @apply text-2xl font-bold tracking-wide;
   }


### PR DESCRIPTION
## Summary
- Add circular hero image component using kuwagata.tron.png
- Implement side-by-side layout with image on left and content on right
- Add social media icons (Twitter, GitHub, LinkedIn, Bluesky) to hero section
- Remove Featured section for cleaner homepage layout

## Changes
- **New HeroImage component**: Circular profile image with hover effects and responsive sizing
- **Updated hero section**: Flex layout with image alongside title, description, and social links
- **Social media integration**: Replace text links with SVG icons matching footer design
- **Layout improvements**: Remove Featured section, adjust spacing and margins
- **Visual enhancements**: Blue divider styling, improved responsive behavior

## Test plan
- [x] Verify circular image displays correctly on desktop and mobile
- [x] Test hover effects on profile image
- [x] Confirm social media icons are clickable and properly styled
- [x] Check responsive layout behavior
- [x] Validate all social links work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)